### PR TITLE
Corriger la redirection d'URL après validation du tag

### DIFF
--- a/src/main/resources/templates/fragments/head.html
+++ b/src/main/resources/templates/fragments/head.html
@@ -15,7 +15,7 @@
 		/*<![CDATA[*/
         emargementContextUrl = '[[@{/{ctx}(ctx=${eContext})}]]';
         selectAll='[[${selectAll}]]';
-		rootUrl='/';
+		rootUrl='[[@{/}]]';
 		seId='[[${seId}]]';
 		currentLocation = '[[${currentLocation}]]';
    		 /*]]>*/


### PR DESCRIPTION
Correction du bug :
Surveillant > Emargement
Scanner une carte sur un téléphone via NFC.
Dans la popup du téléphone "Confirmer le badgeage", cliquer sur Valider. La page web se recharge sur une URL invalide : 404 Not Found

Cela se produit quand Esup-emargement n'est pas installé sur le contexte racine du serveur d'application. Lors de la redirection, il manque le préfixe du contexte.