### PR TITLE
Corriger l'affichage de la photo sur esup-nfc-tag-droid

### DIFF
--- a/src/main/java/org/esupportail/emargement/services/PresenceService.java
+++ b/src/main/java/org/esupportail/emargement/services/PresenceService.java
@@ -672,7 +672,7 @@ public class PresenceService {
 		String eppnTagChecker = taglog.getEppnInit();
 		List<TagCheck> tcs = tagCheckRepository.findBySessionEpreuveIdAndPersonEppn(id, taglog.getEppn());
 		if (!tcs.isEmpty()) {
-           TagChecker tagChecker = sessionEpreuve.getIsSecondTag() ? tcs.get(0).getTagChecker2() : tcs.get(0).getTagChecker();
+           TagChecker tagChecker = (sessionEpreuve.getIsSecondTag() != null && sessionEpreuve.getIsSecondTag()) ? tcs.get(0).getTagChecker2() : tcs.get(0).getTagChecker();
            if (tagChecker != null && tagChecker.getUserApp() != null && eppnTagChecker.equals(tagChecker.getUserApp().getEppn())) {
                isOk = true;
            }


### PR DESCRIPTION
Depuis que je suis passé à esup-emargement-1.1.1, la photo ne s'affiche plus sur esup-nfc-tag-droid (mon ancienne version datait d'il y a un an).

Le souci, c'est que la colonne `is_second_tag` a été ajoutée dans la table `session_epreuve`. Mais ce champ est null pour les anciennes sessions. En conséquence, cela provoque une NullPointerException à cause de l'unboxing. Malheureusement, l'exception est catchée et cela ne produit aucune trace.

Ce patch corrige le problème. 