### PR TITLE
 Prévention des doublons lors de la synchronisation ADE

### DIFF
--- a/src/main/java/org/esupportail/emargement/repositories/SessionLocationRepository.java
+++ b/src/main/java/org/esupportail/emargement/repositories/SessionLocationRepository.java
@@ -3,6 +3,7 @@ package org.esupportail.emargement.repositories;
 import java.util.List;
 
 import org.esupportail.emargement.domain.Context;
+import org.esupportail.emargement.domain.Location;
 import org.esupportail.emargement.domain.SessionEpreuve;
 import org.esupportail.emargement.domain.SessionLocation;
 import org.springframework.data.domain.Page;
@@ -39,6 +40,8 @@ public interface SessionLocationRepository extends JpaRepository<SessionLocation
 	List<SessionLocation> findSessionLocationBySessionEpreuveId(Long Id);
 	
 	 SessionLocation findSessionLocationBySessionEpreuveIdAndLocationNom(Long id, String nom);
+	
+	SessionLocation findBySessionEpreuveAndLocationAndContext(SessionEpreuve sessionEpreuve, Location location, Context context);
 	
 	//STATS
 	@Query(value = "select nom, count(*) from session_location, location, session_epreuve, statut_session "

--- a/src/main/java/org/esupportail/emargement/repositories/TagCheckRepository.java
+++ b/src/main/java/org/esupportail/emargement/repositories/TagCheckRepository.java
@@ -329,6 +329,7 @@ public interface TagCheckRepository extends JpaRepository<TagCheck, Long>{
 	@Query(value = "select * from tag_check, person where tag_check.person_id = person.id and person.eppn= :eppn and session_epreuve_id= :id", nativeQuery = true)
 	TagCheck findTagCheckBySessionEpreuveIdAndEppn(Long id, String eppn);
 	
+	TagCheck findByPersonAndSessionEpreuveAndContext(Person person, SessionEpreuve sessionEpreuve, Context context);
 	
 	//STATS
 	@Query(value = "select (CASE WHEN session_location_badged_id IS NOT NULL THEN 'Present' WHEN session_location_badged_id IS NULL THEN 'Absent' END) as tagcheck,  count(*) "

--- a/src/main/java/org/esupportail/emargement/repositories/TagCheckerRepository.java
+++ b/src/main/java/org/esupportail/emargement/repositories/TagCheckerRepository.java
@@ -49,6 +49,8 @@ public interface TagCheckerRepository extends JpaRepository<TagChecker, Long>{
 	
 	List<TagChecker> findByTagDateIsNull();
 	
+	TagChecker findByUserAppAndSessionLocation(UserApp userApp, SessionLocation sessionLocation);
+	
 	//STATS
 	@Query(value = "select user_app.eppn, count(*) from tag_checker, user_app, session_location, statut_session, session_epreuve "
 			+ "where tag_checker.user_app_id = user_app.id "

--- a/src/main/java/org/esupportail/emargement/services/AdeApiWebService.java
+++ b/src/main/java/org/esupportail/emargement/services/AdeApiWebService.java
@@ -685,13 +685,26 @@ public class AdeApiWebService implements AdeApiService {
 	public void setEvents(String url, List<AdeResourceBean> adeBeans, String existingSe, String sessionId, String resourceId, boolean update, Context ctx, String libelle) throws ParseException, IOException {
 		Map<String, AdeResourceBean>  activities = getActivityFromResource(sessionId, resourceId, null);
 		SimpleDateFormat formatter = new SimpleDateFormat("dd/MM/yyyy");
-		try {
-			Document doc = getDocument(url);
-			doc.getDocumentElement().normalize();
-			NodeList list = doc.getElementsByTagName("event");
-			if(list.getLength() == 0) {
-				log.info("Aucun évènement récupéré.");
-			}else {
+        try {
+            log.info("[ADE-DEBUG] setEvents URL appelée : {}", url);
+            Document doc = getDocument(url);
+            doc.getDocumentElement().normalize();
+            NodeList list = doc.getElementsByTagName("event");
+            if(list.getLength() == 0) {
+                // Dump la racine du XML pour voir ce qu'ADE a vraiment renvoyé
+                java.io.StringWriter sw = new java.io.StringWriter();
+                try {
+                    javax.xml.transform.Transformer t = javax.xml.transform.TransformerFactory.newInstance().newTransformer();
+                    t.setOutputProperty(javax.xml.transform.OutputKeys.OMIT_XML_DECLARATION, "yes");
+                    t.transform(new javax.xml.transform.dom.DOMSource(doc), new javax.xml.transform.stream.StreamResult(sw));
+                } catch (Exception ex) {
+                    sw.write("(impossible de sérialiser le XML : " + ex.getMessage() + ")");
+                }
+                String xml = sw.toString();
+                if (xml.length() > 1500) xml = xml.substring(0, 1500) + "... [tronqué]";
+                log.info("[ADE-DEBUG] Aucun évènement récupéré. XML reçu : {}", xml);
+            }else {
+                log.info("[ADE-DEBUG] {} évènement(s) récupéré(s).", list.getLength());
 				SimpleDateFormat formatter1 = new SimpleDateFormat("HH:mm");
 				String adeSuperGroupe = appliConfigService.getAdeSuperGroupe(ctx);
 				for (int temp = 0; temp < list.getLength(); temp++) {

--- a/src/main/java/org/esupportail/emargement/services/AdeService.java
+++ b/src/main/java/org/esupportail/emargement/services/AdeService.java
@@ -598,21 +598,24 @@ public class AdeService {
 									}
 								}
 								if(!isUnknown) {
-									TagCheck tc = new TagCheck();
-									//A voir 
-									//tc.setCodeEtape(codeEtape);
-									Date endDate =  se.getDateFin() != null? se.getDateFin() : se.getDateExamen();
-									List<Absence> absences = absenceRepository.findOverlappingAbsences(person,
-		                                    se.getDateExamen(), endDate, se.getHeureEpreuve(), se.getFinEpreuve(), ctx);
-									if(!absences.isEmpty()) {
+									TagCheck existing = tagCheckRepository.findByPersonAndSessionEpreuveAndContext(person, se, ctx);
+									if (existing == null) {
+										TagCheck tc = new TagCheck();
+										//A voir 
+										//tc.setCodeEtape(codeEtape);
+										Date endDate =  se.getDateFin() != null? se.getDateFin() : se.getDateExamen();
+										List<Absence> absences = absenceRepository.findOverlappingAbsences(person,
+			                                    se.getDateExamen(), endDate, se.getHeureEpreuve(), se.getFinEpreuve(), ctx);
+										if(!absences.isEmpty()) {
+											nbStudents++;
+						    				tc.setAbsence(absences.get(0));
+						    			}
+										tc.setContext(ctx);
+										tc.setPerson(person);
+										tc.setSessionEpreuve(se);
+										tagCheckRepository.save(tc);
 										nbStudents++;
-					    				tc.setAbsence(absences.get(0));
-					    			}
-									tc.setContext(ctx);
-									tc.setPerson(person);
-									tc.setSessionEpreuve(se);
-									tagCheckRepository.save(tc);
-									nbStudents++;
+									}
 									if(groupes!=null && !groupes.isEmpty()) {
 										groupeService.addPerson(person, groupes);
 									}
@@ -682,15 +685,18 @@ public class AdeService {
 
 					log.debug("Il y a donc "+persons.size()+" participants à ajouter à la session");
 					for (Person person : persons) {
-						TagCheck tc = new TagCheck();
-						// A voir
-						// tc.setCodeEtape(codeEtape);
-						tc.setContext(ctx);
-						tc.setPerson(person);
-						tc.setSessionEpreuve(se);
-						// TODO En profiter pour noter dès maintenant les étudiants avec dispense ??
-						tagCheckRepository.save(tc);
-						nbStudents++;
+						TagCheck existing = tagCheckRepository.findByPersonAndSessionEpreuveAndContext(person, se, ctx);
+						if (existing == null) {
+							TagCheck tc = new TagCheck();
+							// A voir
+							// tc.setCodeEtape(codeEtape);
+							tc.setContext(ctx);
+							tc.setPerson(person);
+							tc.setSessionEpreuve(se);
+							// TODO En profiter pour noter dès maintenant les étudiants avec dispense ??
+							tagCheckRepository.save(tc);
+							nbStudents++;
+						}
 					}
 
 					break;
@@ -705,8 +711,8 @@ public class AdeService {
 	}
 	
 	@Transactional
-	private void processLocations(SessionEpreuve se, AdeResourceBean ade, String sessionId, Context ctx,
-			List<SessionLocation> sls, int nbStudents) throws ParseException {
+    public void processLocations(SessionEpreuve se, AdeResourceBean ade, String sessionId, Context ctx,
+                                 List<SessionLocation> sls, int nbStudents) throws ParseException {
 
 		List<Map<Long, String>> listAdeClassRooms = ade.getClassrooms();
 		boolean isCapaciteSalleEnabled = appliConfigService.isAdeCampusUpdateCapaciteSalleEnabled(ctx);
@@ -803,14 +809,21 @@ public class AdeService {
 	                        ". Ignorés, première Location utilisée.");
 	            }
 	        }
-	        // SessionLocation
-	        SessionLocation sl = new SessionLocation();
-	        sl.setCapacite(location.getCapacite());
-	        sl.setContext(ctx);
-	        sl.setLocation(location);
-	        sl.setSessionEpreuve(se);
-	        sl.setPriorite(1);
-	        sls.add(sessionLocationRepository.save(sl));
+	        
+	        SessionLocation existingSl = sessionLocationRepository.findBySessionEpreuveAndLocationAndContext(se, location, ctx);
+
+			if (existingSl == null) {
+				SessionLocation sl = new SessionLocation();
+				sl.setCapacite(location.getCapacite());
+				sl.setContext(ctx);
+				sl.setLocation(location);
+				sl.setSessionEpreuve(se);
+				sl.setPriorite(1);
+				sls.add(sessionLocationRepository.save(sl));
+			} else {
+				existingSl.setCapacite(location.getCapacite());
+				sls.add(sessionLocationRepository.save(existingSl));
+			}
 	    }
 	    log.info("processLocations terminé pour session " + sessionId);
 	}
@@ -848,11 +861,14 @@ public class AdeService {
 						if(!sls.isEmpty()) {
 							for(SessionLocation sl : sls) {
 								if(userApp != null) {
-									TagChecker tc =  new TagChecker();
-									tc.setContext(ctx);
-									tc.setUserApp(userApp);
-									tc.setSessionLocation(sl);
-									tagCheckerRepository.save(tc);
+									TagChecker existing = tagCheckerRepository.findByUserAppAndSessionLocation(userApp, sl);
+									if (existing == null) {
+										TagChecker tc =  new TagChecker();
+										tc.setContext(ctx);
+										tc.setUserApp(userApp);
+										tc.setSessionLocation(sl);
+										tagCheckerRepository.save(tc);
+									}
 								}else {
 									log.warn("Import surveillant impossible car la personne correspondant à cet email :" + bean.getEmail() + 
 											", n'est pas dans le ldap "  );

--- a/src/main/java/org/esupportail/emargement/services/TaskService.java
+++ b/src/main/java/org/esupportail/emargement/services/TaskService.java
@@ -146,17 +146,20 @@ public class TaskService {
 		List<String> idList = Arrays.asList(task.getParam().split(","));
 		DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
 		List<String> planifications = adeService.getPrefByContext(AdeController.ADE_PLANIFICATION + idProject);
-		
-		if(!planifications.isEmpty()) {
-			int nbJours = Integer.valueOf(planifications.get(0));
-			Date datesDebutFin[] = getStartEndDates(nbJours);
-			String dateDebut = dateFormat.format(datesDebutFin[0]);
-			String dateFin = dateFormat.format(datesDebutFin[1]);
-			task.setDateExecution(new Date());
-			Context ctx = contextRepository.findByKey(emargementContext);
-			
-			List<AdeResourceBean> adebeans = adeService.getAdeBeans(sessionId,
-					dateDebut, dateFin, null, null, null, idList, ctx, true, task.getLibelle());
+
+        if(!planifications.isEmpty()) {
+            int nbJours = Integer.valueOf(planifications.get(0));
+            Date datesDebutFin[] = getStartEndDates(nbJours);
+            String dateDebut = dateFormat.format(datesDebutFin[0]);
+            String dateFin = dateFormat.format(datesDebutFin[1]);
+            task.setDateExecution(new Date());
+            Context ctx = contextRepository.findByKey(emargementContext);
+
+            log.info("[ADE-DEBUG] ctx={} task='{}' idProject={} sessionId={} nbJours={} dateDebut={} dateFin={} idList={} param='{}'",
+                    emargementContext, task.getLibelle(), idProject, sessionId, nbJours, dateDebut, dateFin, idList, task.getParam());
+
+            List<AdeResourceBean> adebeans = adeService.getAdeBeans(sessionId,
+                    dateDebut, dateFin, null, null, null, idList, ctx, true, task.getLibelle());
 			List<Long> idEvents = adebeans.stream()
 					.map(tc -> tc.getEventId())
 					.collect(Collectors.toList());


### PR DESCRIPTION
## PR : Prévention des doublons lors de la synchronisation ADE

###  Contexte et Problème
Un bug majeur survenait lors de la synchronisation d'une session depuis ADE, particulièrement lorsqu'une session était replanifiée à son heure initiale. L'import créait alors des doublons dans la base de données pour les salles (`SessionLocation`), les participants (`TagCheck`) et les surveillants (`TagChecker`).

Ces duplications provoquaient par la suite une exception fatale `NonUniqueResultException` (les requêtes de l'application attendant un résultat unique en recevaient plusieurs). Ce crash bloquait des processus critiques, notamment le **badgeage NFC** des étudiants.

###  Modifications apportées
Pour corriger ce comportement, nous avons rendu les méthodes d'importation idempotentes en ajoutant des vérifications d'existence avant toute nouvelle insertion en base :

1. **Ajout de méthodes de recherche spécifiques dans les Repositories** :
   - `SessionLocationRepository` : Ajout de `findBySessionEpreuveAndLocationAndContext`
   - `TagCheckRepository` : Ajout de `findByPersonAndSessionEpreuveAndContext`
   - `TagCheckerRepository` : Ajout de `findByUserAppAndSessionLocation`

2. **Sécurisation de la création dans `AdeService`** :
   - **Lieux (`processLocations`)** : On vérifie si l'association session-salle existe déjà. Si oui, on met simplement à jour sa capacité, sinon on la crée.
   - **Participants** : On insère le `TagCheck` uniquement si l'étudiant/le participant n'est pas déjà enregistré pour cette session et ce contexte.
   - **Surveillants** : On insère le `TagChecker` uniquement si l'utilisateur n'est pas déjà assigné à cette salle de session.

###  Améliorations et Bénéfices
* **Résolution du blocage NFC** : En garantissant l'unicité des enregistrements, l'erreur `NonUniqueResultException` ne se déclenche plus lors du passage de la carte.
* **Idempotence de l'import** : La synchronisation ADE peut désormais être relancée de manière répétée ou gérer des replanifications complexes sans jamais polluer ou corrompre les données.
* **Intégrité des données** : Les relations entre les sessions, les utilisateurs et les lieux restent saines et conformes à ce qui est attendu par la structure de l'application.