### PR TITLE
ajout de la valeur DISPENSE à l'enumération MotifAsbence.TypeAbsence

### DIFF
--- a/src/main/java/org/esupportail/emargement/domain/MotifAbsence.java
+++ b/src/main/java/org/esupportail/emargement/domain/MotifAbsence.java
@@ -32,7 +32,7 @@ public class MotifAbsence {
 	private Context context;
 	
 	public static enum TypeAbsence {
-	       ABSENCE, EXCLUSION, RETARD
+	       ABSENCE, EXCLUSION, RETARD, DISPENSE
 	}
 	
 	public static enum StatutAbsence {


### PR DESCRIPTION
# Ajout du type d'absence « Dispense »

## Contexte

L'application ne propose actuellement que trois types de motif d'absence : **Absence**, **Exclusion** et **Retard** (`MotifAbsence.TypeAbsence`). Or, dans le vocabulaire de la scolarité, il existe une situation distincte de l'absence « classique » : la **dispense** (aussi appelée **aménagement de scolarité**), où l'étudiant n'assiste pas au cours pour une raison prévue et validée par la formation, et non par manquement.

Assimiler ces cas à une simple « absence » fausse le suivi d'assiduité et la lecture des états d'émargement : un étudiant dispensé n'est pas un étudiant absent.

## Besoin

Ajouter un type **`DISPENSE`** permet d'identifier explicitement, sur la fiche d'émargement, qu'un étudiant est légitimement dispensé d'un cours ou d'un module.

## Exemples de cas d'usage

- **Redoublement / compétence déjà acquise** : un étudiant ayant redoublé a déjà validé la compétence d'un cours spécifique ; il est dispensé d'y réassister.
- **Formations en alternance** : certains modules sont considérés comme dispensés côté établissement car la compétence est acquise/validée dans la partie entreprise du cursus.
- **Validation des acquis / équivalences** : un module déjà validé au titre d'un diplôme antérieur, d'une VAE ou d'une équivalence entre parcours.
- **Aménagements de scolarité** : étudiants sportifs de haut niveau, salariés, en situation de handicap, chargés de famille, élus étudiants… bénéficiant d'un aménagement dispensant de certains créneaux.
- **Mobilité / échanges** : cours suivis dans un autre établissement (mobilité entrante/sortante) et donc dispensés localement.

Dans tous ces cas, le vocabulaire de la scolarité parle de **dispense** ou d'**aménagement** : la présence n'est pas requise et l'absence physique ne doit pas être comptabilisée comme un manquement.

## Modification

Ajout de la valeur `DISPENSE` à l'énumération `MotifAbsence.TypeAbsence`. Les formulaires de création/édition de motif alimentant leurs listes par réflexion (`TypeAbsence.values()`) et le stockage se faisant en `EnumType.STRING`, le nouveau type est disponible immédiatement dans l'interface, **sans migration de schéma**. Les gestionnaires peuvent ensuite créer un ou plusieurs motifs de type « Dispense » via *Gestionnaire → Motifs absence*, avec la case *Comptabilisation (Malus)* décochée pour que ces situations ne soient pas comptées comme des manquements.
